### PR TITLE
Add the noop 'importScripts' worker function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ global.Worker = function Worker(url) {
 			postMessage(data) {
 				outside.emit('message', { data });
 			},
-			fetch: global.fetch
+			fetch: global.fetch,
+			importScripts(...urls) {}
 		},
 		getScopeVar;
 	inside.on('message', e => { let f = getScopeVar('onmessage'); if (f) f.call(scope, e); });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,8 @@
 import 'jsdom-worker';
 
+import fs from 'fs';
+import path from 'path';
+
 const sleep = t => new Promise( r => { setTimeout(r, t); });
 
 describe('jsdom-worker', () => {
@@ -10,5 +13,15 @@ describe('jsdom-worker', () => {
 		worker.postMessage(5);
 		await sleep(10);
 		expect(worker.onmessage).toHaveBeenCalledWith({ data: 10 });
+	});
+
+	it('should work with importScripts', async () => {
+		const mod = fs.readFileSync(path.join(__dirname, './module.js'));
+		const code = fs.readFileSync(path.join(__dirname, './worker.js'));
+		const worker = new Worker(URL.createObjectURL(new Blob([mod + code])));
+		worker.onmessage = jest.fn();
+		worker.postMessage();
+		await sleep(10);
+		expect(worker.onmessage).toHaveBeenCalledWith({ data: 'test' });
 	});
 });

--- a/test/module.js
+++ b/test/module.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-unused-vars */
+const importedModule = {
+	string: 'test'
+};

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef */
+importScripts('module.js');
+
+onmessage = () => { postMessage(importedModule.string); };


### PR DESCRIPTION
First of all, thanks for the very useful project. This PR adds a noop version of the worker's `importScripts` function so that it is possible to test workers that import other scripts. It also adds a test case for it which can also serve as an example of how one could test a worker which uses the `importScripts` function. 