### PR TITLE
Add link `homepage` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "extends": "eslint-config-developit"
   },
   "author": "Jason Miller <jason@developit.ca> (http://jasonformat.com)",
+  "homepage": "https://github.com/developit/jsdom-worker",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
I believe that this will cause npmjs.com to link to the repository