### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "prepare": "npm run -s build && npm t",
     "release": "npm t && git commit -am \"$npm_package_version\" && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/developit/jsdom-worker.git"
+  },
   "babel": {
     "presets": [
       [

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "prepare": "npm run -s build && npm t",
     "release": "npm t && git commit -am \"$npm_package_version\" && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/developit/jsdom-worker.git"
-  },
+  "repository": "developit/jsdom-worker",
   "babel": {
     "presets": [
       [


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources. 

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR. 

Published NPM packages with repository information:
• jsdom-worker